### PR TITLE
Replace CakePlugin::load by Plugin::load

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Usage
 
 In app/Config/bootstrap.php add:
 ```
-CakePlugin::load('CakeExcel', array('bootstrap' => true, 'routes' => true));
+Plugin::load('Dakota\CakeExcel', ['bootstrap' => true, 'routes' => true]);
 ```
 
 


### PR DESCRIPTION
The CakePlugin does not exist.
Folder structure: /app/plugins/Dakota/CakeExcel so we've to load plugin like this:
Plugin::load('Dakota\CakeExcel', ['bootstrap' => true, 'routes' => true]);
