### PR TITLE
replace ext by _ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add the RequestHandler component to AppController, and map xlsx to the CakeExcel
 
 Create a link to the a action with the .xlsx extension
 ```
-$this->Html->link('Excel file', array('ext' => 'xlsx'));
+$this->Html->link('Excel file', array('_ext' => 'xlsx'));
 ```
 
 Place the view templates in a 'xlsx' subdir, for instance `src/Template/Invoices/xlsx/index.ctp`, you also need a layout file, `src/Template/Layout/xlsx/default.ctp`


### PR DESCRIPTION
From CakePHP 3.0 beta 3, you must use _ext to set extension.
ext does not exist anymore.